### PR TITLE
Adding name to button to fix Store project build

### DIFF
--- a/ms/vstemplates/OpenSSLTestAppStore8.1/MainPage.xaml
+++ b/ms/vstemplates/OpenSSLTestAppStore8.1/MainPage.xaml
@@ -16,7 +16,7 @@
         <StackPanel x:Name="MainPanel" Grid.Row="0" Margin="12,17,0,28">
             <TextBlock Text="OpenSSL Test App" Margin="12,0"/>
             <TextBlock x:Name="Title" Text="" Margin="9,-7,0,0" FontSize="35"/>
-            <Button Click="Button_Click" >Run Tests</Button>
+            <Button x:Name="RunTests" Click="Button_Click" >Run Tests</Button>
         </StackPanel>
 
         <!--ContentPanel - place additional content here-->


### PR DESCRIPTION
A previous commit (https://github.com/Microsoft/openssl/commit/21d2dc25cddef263d7ded4dd37d21178d7b3dd0d) made changes to the code behind used by all projects, and also to the xaml for the phone projects.

The xaml for the Store project was left unchanged, thus breaking the build.