### PR TITLE
Fixes builds where environment variable has backslashes

### DIFF
--- a/ms/do_vsproject.pl
+++ b/ms/do_vsproject.pl
@@ -213,7 +213,7 @@ sub processBatch{
         my $var = (split('=',$words[1]))[0];
         my $val = substr($line, $ind+1);
         $env{$var}=$val;
-        $function.=tab()."//set $var=$env{$var}\n";
+        $function.=tab()."//set $var=\"$env{$var}\"\n";
         next;
       }
 
@@ -257,7 +257,7 @@ sub processBatch{
       my $var = (split('=',$line))[0];
       my $val = substr($line, $ind+1);
       $env{$var}=$val;
-      $function.=tab()."//$var=$env{$var}\n";
+      $function.=tab()."//$var=\"$env{$var}\"\n";
       next;
     }
     if(index($line,":")!=-1)


### PR DESCRIPTION
If an environment variable such as PATH contains a backslash Visual Studio interprets the next line as part of the comment. When a user attempts to build the .sln he or she will see errors relating to a missing brace "}".

Before fix, the following code is generated in winrtcomponent.cpp and Visual Studio does not recognize the brace in the line ```}//end:ms\test.bat```

```C#
...
    end_0:
    echo("end_0:");
    //PATH=C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\;C:\Program Files (x86)\MSBuild\12.0\bin;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\VCPackages;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Team Tools\Performance Tools;C:\Program Files (x86)\Windows Kits\8.1\bin\x86;C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\;C:\Perl64\site\bin;C:\Perl64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\Intel\WiFi\bin\;C:\Program Files\Common Files\Intel\WirelessCommon\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Microsoft SQL Server\110\Tools\Binn\;C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Perforce;C:\Program Files\Intel\WiFi\bin\;C:\Program Files\Common Files\Intel\WirelessCommon\
}//end:ms\test.bat
...
```

The user will see error messages of this type:
````
...
Error	75	error C1075: end of file found before the left brace '{' at 'C:\Users\Seecrypt\git\openssl\vsout\\winrtcomponent.cpp(105)' was matched	C:\Users\Seecrypt\git\openssl\vsout\\winrtcomponent.cpp	1412	1	NT-Phone-8.1-Dll-Unicode-winrtcomponent
...
````

By encapsulating the environment variable contents in quotation marks we can prevent Visual Studio from marking the brace in "```}//end:ms\test.bat```" as being a comment. Generated code with fix:

```C#
...
    end_0:
		echo("end_0:");
		//PATH="C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow;C:\Program Files (x86)\Microsoft SDKs\F#\3.1\Framework\v4.0\;C:\Program Files (x86)\MSBuild\12.0\bin;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\BIN;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\Tools;C:\Windows\Microsoft.NET\Framework\v4.0.30319;C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\VCPackages;C:\Program Files (x86)\HTML Help Workshop;C:\Program Files (x86)\Microsoft Visual Studio 12.0\Team Tools\Performance Tools;C:\Program Files (x86)\Windows Kits\8.1\bin\x86;C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\;C:\Users\Dino\ConEmuPack.141206;C:\Users\Dino\ConEmuPack.141206\ConEmu;C:\Perl64\site\bin;C:\Perl64\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Program Files\Intel\WiFi\bin\;C:\Program Files\Common Files\Intel\WirelessCommon\;C:\Program Files (x86)\Windows Kits\8.1\Windows Performance Toolkit\;C:\Program Files\Microsoft SQL Server\110\Tools\Binn\;C:\Program Files (x86)\Microsoft SDKs\TypeScript\1.0\;C:\Program Files\Microsoft SQL Server\120\Tools\Binn\;C:\Program Files\Perforce;C:\Program Files\Intel\WiFi\bin\;C:\Program Files\Common Files\Intel\WirelessCommon\"
	}//end:ms\test.bat
...
```
