### PR TITLE
Fix ms/setVSvars.bat to use %_WKITS10% instead of hard coding to "c:\…

### DIFF
--- a/ms/setVSvars.bat
+++ b/ms/setVSvars.bat
@@ -178,7 +178,7 @@ exit /b
 	set PATH=%_VS14VC\Bin%;%PATH%
 	set INCLUDE=%_VS14VC%\include;%_WKITS10%\Include\%_WKITS10VER%\um;%_WKITS10%\Include\%_WKITS10VER%\shared;%_WKITS10%\Include\%_WKITS10VER%\winrt;%_WKITS10%\Include\%_WKITS10VER%\ucrt;
 	set LIB=%_VS14VC%\lib\store\%_VCLibPlat%;%_WKITS10%\lib\%_WKITS10VER%\um\%_VCPlatform%;%_WKITS10%\Lib\%_WKITS10VER%\ucrt\%_VCPlatform%;
-	set LIBPATH=%_WKITS10%\UnionMetadata\Facade;%_VS14VC%\vcpackages;c:\program files (x86)\windows kits\10\references\windows.foundation.foundationcontract\1.0.0.0\;c:\program files (x86)\windows kits\10\references\windows.foundation.universalapicontract\1.0.0.0\
+	set LIBPATH=%_WKITS10%\UnionMetadata\Facade;%_VS14VC%\vcpackages;;%_WKITS10%\references\windows.foundation.foundationcontract\1.0.0.0\;;%_WKITS10%\references\windows.foundation.universalapicontract\1.0.0.0\
 	goto :eof
 
 :end


### PR DESCRIPTION
  Fix ms/setVSvars.bat to use %_WKITS10% instead of hard coding to "c:\programs files(x86)\windows kits\10
