### PR TITLE
I don't know how it works with other versions, but with 10.0.10586.0,…

### DIFF
--- a/ms/setVSvars.bat
+++ b/ms/setVSvars.bat
@@ -166,7 +166,7 @@ exit /b
 :set_WKITS10VER
 	if not "%_WKITS10VER%"=="" goto :eof
 	call:setRegVar "HKLM\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0" ProductVersion _WKITS10VER
-	set _WKITS10VER=%_WKITS10VER%.0
+REM	set _WKITS10VER=%_WKITS10VER%.0
 	echo %_WKITS10VER%
 	if not "%_WKITS10VER%"=="" goto :eof
 	goto :eof


### PR DESCRIPTION
… the line I commented out would add an extra zero, to become '10.0.10586.0.0' and the include paths would be all wrong and nothing would compile
