### PR TITLE
Removed WINAPI declaration to prevent @ decoration of function name

### DIFF
--- a/ms/winrt.cpp
+++ b/ms/winrt.cpp
@@ -144,7 +144,7 @@ extern "C"
 		return NULL;
 		}
 
-	BOOL WINAPI GetVersionEx(
+	BOOL GetVersionEx(
 							_Inout_  LPOSVERSIONINFO lpVersionInfo
 							)
 		{
@@ -165,11 +165,11 @@ extern "C"
 		{
 		return 0;
 		}
-	int WINAPI GetProcessWindowStation(void)
+	int GetProcessWindowStation(void)
 		{
 		return NULL;
 		}
-	BOOL WINAPI GetUserObjectInformationW(
+	BOOL GetUserObjectInformationW(
 										 _In_       HANDLE hObj,
 										 _In_       int nIndex,
 										 _Out_opt_  PVOID pvInfo,
@@ -180,7 +180,7 @@ extern "C"
 		return 0;
 		}
 #ifndef STD_ERROR_HANDLE
-	int WINAPI GetStdHandle(
+	int GetStdHandle(
 						   _In_  DWORD nStdHandle
 						   )
 		{
@@ -208,7 +208,7 @@ extern "C"
 		{
 		return -1;
 		}
-	void WINAPI GlobalMemoryStatus(
+	void GlobalMemoryStatus(
 								  _Out_  LPMEMORYSTATUS lpBuffer
 								  )
 		{
@@ -279,7 +279,7 @@ extern "C"
 		return 0;
 		}
 
-	BOOL WINAPI FlushConsoleInputBuffer(
+	BOOL FlushConsoleInputBuffer(
 									   _In_  HANDLE hConsoleInput
 									   )
 		{


### PR DESCRIPTION
Hello. I've got linking error "LNK2001 unresolver external symbol" while linking libeay32.lib, 
which were build for UWP, namely these function were not found:
error LNK2001: unresolved external symbol FlushConsoleInputBuffer@
error LNK2001: unresolved external symbol GetProcessWindowStation@
error LNK2001: unresolved external symbol GetUserObjectInformationW@
error LNK2001: unresolved external symbol GetVersionEx@
error LNK2001: unresolved external symbol GlobalMemoryStatus@
These functions are declared in ms\winrt.cpp and only these functions have WINAPI specification 
(+ GetStdHandle, but under STD_ERROR_HANDLE define), all other Win Api stubs are declared without WINAPI specification (see the file). This WINAPI declaration forces compiler to decorate name with '@', therefore functions cannot be found.
Without WINAPI declaration everything is OK.
