### PR TITLE
Fix and simplify setVSvars.bat for current Visual Studio 2015 versions

### DIFF
--- a/ms/setVSvars.bat
+++ b/ms/setVSvars.bat
@@ -178,11 +178,8 @@ exit /b
 :setEnv
 	call:setVar _VS14VC VisualStudio14VC
 	call:setVar _WKITS10 WindowsKits10.0
-	call:setVar _WKITS10VER WindowsKits10Version
-	set PATH=%_VS14VC\Bin%;%PATH%
-	set INCLUDE=%_VS14VC%\include;%_WKITS10%\Include\%_WKITS10VER%\um;%_WKITS10%\Include\%_WKITS10VER%\shared;%_WKITS10%\Include\%_WKITS10VER%\winrt;%_WKITS10%\Include\%_WKITS10VER%\ucrt;
-	set LIB=%_VS14VC%\lib\store\%_VCLibPlat%;%_WKITS10%\lib\%_WKITS10VER%\um\%_VCPlatform%;%_WKITS10%\Lib\%_WKITS10VER%\ucrt\%_VCPlatform%;
-	set LIBPATH=%_WKITS10%\UnionMetadata\Facade;%_VS14VC%\vcpackages;;%_WKITS10%\references\windows.foundation.foundationcontract\1.0.0.0\;;%_WKITS10%\references\windows.foundation.universalapicontract\1.0.0.0\
+	set PATH=%_VS14VCBin%;%PATH%
+	set "LIBPATH=%_WKITS10%UnionMetadata\Facade;%_VS14VC%vcpackages;%_WKITS10%references\windows.foundation.foundationcontract\1.0.0.0\;%_WKITS10%references\windows.foundation.universalapicontract\1.0.0.0\"
 	goto :eof
 
 :end


### PR DESCRIPTION
This pull request fixes compile errors with recent VS versions and simplifies the setVSvars.bat to the minimum needed to make compiles with recent VS versions work out of the box.

For recent VS versions things have changed slightly:

- The include paths are no longer set correctly. ms\setVSvars.bat reads the registry to set _WKITS10VER to 10.0.14393 but the include folder names are below a folder named 10.0.14393.0. This is already mentioned in issue #34 .
- ms\setVSvars.bat also reads the registry to set _VS14VC. The stored registry value contains a trailing \ which must be removed in the SET statements of the environment variables to correctly set them up.

After some experimentation I found out that the INCLUDE and LIB environment variables are already set correctly through the call to vcvarsall.bat. Only the LIBPATH needed tweaking.