### PR TITLE
Fix wrong preprocessor condition for Win10 SDK that < WIN10_RS4.

### DIFF
--- a/ms/winrt.cpp
+++ b/ms/winrt.cpp
@@ -46,10 +46,13 @@ unsigned entropyRT(BYTE *buffer, unsigned len)
 }
 
 #else
+#pragma warning ( push )
+#pragma warning ( disable : 4467 )
 #include <roapi.h>
 #include <robuffer.h>
 #include <windows.security.cryptography.h>
 #include <winstring.h>
+#pragma warning ( pop )
 
 unsigned entropyRT(BYTE *buffer, unsigned len)
 {

--- a/ms/winrtdef.h
+++ b/ms/winrtdef.h
@@ -14,7 +14,7 @@
 #if defined(OPENSSL_WINAPP)
 //Include stdio.h to replace fprintf
 # include <stdio.h>
-# if !defined(NTDDI_VERSION) || (NTDDI_VERSION < NTDDI_WIN10_RS4)
+# if !defined(NTDDI_WIN10_RS4) || (NTDDI_VERSION < NTDDI_WIN10_RS4)
 #  ifdef getenv
 #   undef getenv
 #  endif


### PR DESCRIPTION
Simple fix of a wrong define. Since the WIN10_RS4 DDK has getenv defined we don't need to override it.
